### PR TITLE
Support for Galactic War Overhaul loadouts

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -12,10 +12,10 @@
   "priority": 100,
   "scenes": {
     "start": [
-      "coui://ui/mods/gw_unlock_loadouts/start.js"
+      "coui://ui/mods/gw_unlock_loadouts/start.js",
+      "coui://ui/mods/gw_unlock_loadouts/gwo.js"
     ]
   },
   "signature": "not yet implemented",
   "version": "1.0.2"
 }
-

--- a/ui/mods/gw_unlock_loadouts/gwo.js
+++ b/ui/mods/gw_unlock_loadouts/gwo.js
@@ -1,0 +1,2 @@
+localStorage["gwaio_bank"] =
+  '{"startCards":[{"id":"gwaio_start_ceo"},{"id":"gwaio_start_paratrooper"},{"id":"nem_start_deepspace"},{"id":"nem_start_nuke"},{"id":"nem_start_planetary"},{"id":"nem_start_tower_rush"},{"id":"gwaio_start_tourist"},{"id":"gwaio_start_rapid"},{"id":"tgw_start_speed"},{"id":"tgw_start_tank"},{"id":"gwaio_start_nomad"},{"id":"gwaio_start_backpacker"},{"id":"gwaio_start_hoarder"}]}';

--- a/ui/mods/gw_unlock_loadouts/start.js
+++ b/ui/mods/gw_unlock_loadouts/start.js
@@ -1,1 +1,2 @@
-localStorage['gw_bank'] = '{"startCards":[{"id":"gwc_start_vehicle"},{"id":"gwc_start_air"},{"id":"gwc_start_orbital"},{"id":"gwc_start_bot"},{"id":"gwc_start_artillery"},{"id":"gwc_start_subcdr"},{"id":"gwc_start_combatcdr"},{"id":"gwc_start_allfactory"}]}'
+localStorage["gw_bank"] =
+  '{"startCards":[{"id":"gwc_start_vehicle"},{"id":"gwc_start_air"},{"id":"gwc_start_orbital"},{"id":"gwc_start_bot"},{"id":"gwc_start_artillery"},{"id":"gwc_start_subcdr"},{"id":"gwc_start_combatcdr"},{"id":"gwc_start_allfactory"},{"id":"gwc_start_storage"}]}';


### PR DESCRIPTION
### Changes

1. Unlocks all loadouts added by Galactic War Overhaul
2. Unlocks the Storage Commander, a vanilla loadout exposed by Galactic War Overhaul

### Known issues

1. Storage Commander will be unlocked for vanilla players despite not being unlockable without GWO